### PR TITLE
Migrate to new salt domain

### DIFF
--- a/master/master.jinja
+++ b/master/master.jinja
@@ -299,7 +299,7 @@ interface: '{{ interface }}'
 ##########################################
 # Enable passphrase protection of Master private key.  Although a string value
 # is acceptable; passwords should be stored in an external vaulting mechanism
-# and retrieved via sdb. See https://docs.saltstack.com/en/latest/topics/sdb/.
+# and retrieved via sdb. See https://docs.saltproject.io/en/latest/topics/sdb/.
 # Passphrase protection is off by default but an example of an sdb profile and
 # query is as follows.
 # masterkeyring:
@@ -965,7 +965,7 @@ pillar_roots:
 # configuration options to fully understand the tunable parameters and their implications.
 #
 # Note: setting ``pillar_cache: True`` has no effect on targeting Minions with Pillars.
-# See https://docs.saltstack.com/en/latest/topics/targeting/pillar.html
+# See https://docs.saltproject.io/en/latest/topics/targeting/pillar.html
 #pillar_cache: False
 
 # If and only if a master has set ``pillar_cache: True``, the cache TTL controls the amount
@@ -995,7 +995,7 @@ pillar_roots:
 
 ######        Reactor Settings        #####
 ###########################################
-# Define a salt reactor. See https://docs.saltstack.com/en/latest/topics/reactor/
+# Define a salt reactor. See https://docs.saltproject.io/en/latest/topics/reactor/
 #reactor: []
 
 #Set the TTL for the cache of the reactor configuration.

--- a/minion/minion.jinja
+++ b/minion/minion.jinja
@@ -498,7 +498,7 @@ ipv6: True
 # templating on the SLS file, and then load the result as YAML. This syntax is
 # documented in further depth at the following URL:
 #
-# https://docs.saltstack.com/en/latest/ref/renderers/#composing-renderers
+# https://docs.saltproject.io/en/latest/ref/renderers/#composing-renderers-a-k-a-the-render-pipeline
 #
 # NOTE: The "shebang" prefix (e.g. "#!jinja|yaml") described in the
 # documentation linked above is for use in an SLS file to override the default
@@ -723,7 +723,7 @@ master_finger: '{{ master_finger }}'
 
 ######        Reactor Settings        #####
 ###########################################
-# Define a salt reactor. See https://docs.saltstack.com/en/latest/topics/reactor/
+# Define a salt reactor. See https://docs.saltproject.io/en/latest/topics/reactor/
 #reactor: []
 
 #Set the TTL for the cache of the reactor configuration.

--- a/repository.sls
+++ b/repository.sls
@@ -1,6 +1,6 @@
 # Setup official saltstack repository
 saltstack_repo:
   pkgrepo.managed:
-    - name: deb http://repo.saltstack.com/py3/{{ grains['os']|lower }}/{{ grains['osrelease'] }}/{{ grains['osarch'] }}/latest {{ grains['oscodename'] }} main
+    - name: deb https://repo.saltproject.io/salt/py3/{{ grains['os']|lower }}/{{ grains['osrelease'] }}/{{ grains['osarch'] }}/latest {{ grains['oscodename'] }} main
     - file: /etc/apt/sources.list.d/saltstack.list
-    - key_url: https://repo.saltstack.com/py3/{{ grains['os']|lower }}/{{ grains['osrelease'] }}/{{ grains['osarch'] }}/latest/SALTSTACK-GPG-KEY.pub
+    - key_url: https://repo.saltproject.io/salt/py3/{{ grains['os']|lower }}/{{ grains['osrelease'] }}/{{ grains['osarch'] }}/latest/salt-archive-keyring.gpg


### PR DESCRIPTION
Salt has changed its base URL recently from saltstack.com to saltproject.io.